### PR TITLE
validator增加根据path清空错误数据的功能

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -103,6 +103,7 @@ function Validator(store, rules, opts) {
   return {
     isValid: this.isValid.bind(this),
     rule: this.rule.bind(this),
+    clearError: this.clearError.bind(this),
     fieldErrors: function () {
       return this.fieldErrors.toJS();
     }.bind(this)
@@ -119,6 +120,24 @@ function Validator(store, rules, opts) {
 Validator.prototype.rule = function (name, callback) {
   this[name] = callback;
 };
+
+
+/**
+ * 清空错误信息
+ * @path 要清空的错误信息路径,不传默认清空所有
+ *
+ */
+Validator.prototype.clearError = function(path) {
+  if (path) {
+    // 获取path对应的值
+    var pathArr = path.split("\.");
+    // 根据传入的path清空错误信息
+    this.fieldErrors = this.fieldErrors[_.isArray(pathArr) ? 'removeIn' : 'remove'](pathArr);
+  } else {
+    // 如果没有传path默认清空所有的错误
+    this.fieldErrors = Immutable.OrderedMap({});
+  }
+}
 
 
 /**

--- a/test/hi-iflux.js
+++ b/test/hi-iflux.js
@@ -30,7 +30,7 @@ console.log('store data->', appStore.data().toString());
 
 //获取store数据的cursor
 //console.log(appStore.cursor());
-console.log('cursor->', appStore.cursor().toString());
+//console.log('cursor->', appStore.cursor().toString());
 
 /**
  * validator
@@ -90,11 +90,17 @@ validator.rule('customRequired', function(param, val) {
 
 
 //validator all
-validator.isValid();
-console.log('fieldErros->', validator.fieldErrors());
+//validator.isValid();
+//console.log('fieldErros->', validator.fieldErrors());
 
 //validator confirm
-//validator.isValid('form.confirm');
+validator.isValid('form.confirm');
+validator.isValid('form.username');
+validator.clearError('form.confirm');
+//validator.clearError();
+validator.isValid('form.password');
+console.log('fieldErros->',appStore.data().toString());
+
 
 appStore.cursor().set('form', Immutable.fromJS({
   username: 'hf',
@@ -102,12 +108,12 @@ appStore.cursor().set('form', Immutable.fromJS({
   confirm: '(:'
 }));
 
-console.log(appStore.data().get('form').toString());
 
+//console.log(appStore.data().get('form').toString());
 // appStore.reset('form');
 // console.log(appStore.data().get('form').toString());
 
 //appStore.reset(['form', 'username'])
-appStore.reset(); //rollback
-console.log('reset->');
-console.log(appStore.data().get('form').toString());
+//appStore.reset(); //rollback
+//console.log('reset->');
+//console.log(appStore.data().get('form').toString());


### PR DESCRIPTION
validator支持单个路径校验，比如validator.isValid('form.name')
但是当我分别进行两次校验时，比如：validator.isValid('form.name');  validator.isValid('form.password')
第二次的校验会带出第一次校验的错误，这是因为Validator对象中fieldErrors在第一次校验后没有清空，本次pullrequest在Validator中扩展一个清空fieldErrors的方法。